### PR TITLE
[1.0.2] ViewPager setCurrentItem bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A lightweight, plug-and-play indefinite pager indicator for RecyclerViews &amp; 
 To use the IndefinitePagerIndicator, simply add the gradle dependency to your module's `build.gradle` file:
 
 ```groovy
-compile 'com.ryanjeffreybrooks:indefinitepagerindicator:1.0.1'
+compile 'com.ryanjeffreybrooks:indefinitepagerindicator:1.0.2'
 ```
 
 ## Getting Started

--- a/indefinitepagerindicator/build.gradle
+++ b/indefinitepagerindicator/build.gradle
@@ -15,11 +15,11 @@ ext {
     siteUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator'
     gitUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator.git'
 
-    libraryVersion = '1.0.1'
+    libraryVersion = '1.0.2'
 
     developerId = 'rbro112'
     developerName = 'Ryan Brooks'
-    developerEmail = 'ryanjeffrey.brooks112@yahoo.com'
+    developerEmail = 'ryanjeffrey.brooks112@gmail.com'
 
     licenseName = 'MIT License'
     licenseUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator/blob/master/LICENSE.md'

--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -60,7 +60,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
     /**
      * The scroll percentage of the viewpager or recyclerview.
      * Used for moving the dots/scaling the fading dots.
-      */
+     */
     private var offsetPercent: Float = 0f
 
     init {
@@ -230,7 +230,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
         offsetPercent = positionOffset * -1
         invalidate()
     }
-
+    
     override fun onPageSelected(position: Int) {
         intermediateSelectedItemPosition = selectedItemPosition
         selectedItemPosition = position

--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -232,6 +232,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
     }
 
     override fun onPageSelected(position: Int) {
+        intermediateSelectedItemPosition = selectedItemPosition
         selectedItemPosition = position
         invalidate()
     }

--- a/sample/src/main/java/com/rbrooks/indefinitepagerindicatorsample/viewPagerSample/ViewPagerSampleFragment.kt
+++ b/sample/src/main/java/com/rbrooks/indefinitepagerindicatorsample/viewPagerSample/ViewPagerSampleFragment.kt
@@ -40,7 +40,8 @@ class ViewPagerSampleFragment : Fragment(), OnPagerNumberChangeListener, View.On
         viewPager.adapter = pagerAdapter
         pagerIndicator.attachToViewPager(viewPager)
 
-
+        previousButton.setOnClickListener(this)
+        nextButton.setOnClickListener(this)
     }
 
     override fun onPagerNumberChanged() {

--- a/sample/src/main/java/com/rbrooks/indefinitepagerindicatorsample/viewPagerSample/ViewPagerSampleFragment.kt
+++ b/sample/src/main/java/com/rbrooks/indefinitepagerindicatorsample/viewPagerSample/ViewPagerSampleFragment.kt
@@ -6,15 +6,17 @@ import android.support.v4.view.ViewPager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import com.rbrooks.indefinitepagerindicator.IndefinitePagerIndicator
 import com.rbrooks.indefinitepagerindicatorsample.R
 import com.rbrooks.indefinitepagerindicatorsample.util.OnPagerNumberChangeListener
 
-class ViewPagerSampleFragment : Fragment(), OnPagerNumberChangeListener {
-
+class ViewPagerSampleFragment : Fragment(), OnPagerNumberChangeListener, View.OnClickListener {
     private lateinit var viewPager: ViewPager
-    private lateinit var pagerIndicator: IndefinitePagerIndicator
 
+    private lateinit var pagerIndicator: IndefinitePagerIndicator
+    private lateinit var previousButton: Button
+    private lateinit var nextButton: Button
     private var pagerAdapter: ViewPagerAdapter? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -29,15 +31,38 @@ class ViewPagerSampleFragment : Fragment(), OnPagerNumberChangeListener {
     private fun bindViews(view: View) {
         viewPager = view.findViewById(R.id.viewpager)
         pagerIndicator = view.findViewById(R.id.viewpager_pager_indicator)
+        previousButton = view.findViewById(R.id.viewpager_previous_button)
+        nextButton = view.findViewById(R.id.viewpager_next_button)
     }
 
     private fun setupViews() {
         pagerAdapter = ViewPagerAdapter(context)
         viewPager.adapter = pagerAdapter
         pagerIndicator.attachToViewPager(viewPager)
+
+
     }
 
     override fun onPagerNumberChanged() {
         pagerAdapter?.notifyDataSetChanged()
+    }
+
+    override fun onClick(v: View?) {
+        when (v?.id) {
+            R.id.viewpager_previous_button -> {
+                if (viewPager.currentItem == 0) {
+                    viewPager.currentItem = viewPager.adapter.count - 1
+                } else {
+                    viewPager.currentItem = viewPager.currentItem - 1
+                }
+            }
+            R.id.viewpager_next_button -> {
+                if (viewPager.currentItem == viewPager.adapter.count - 1) {
+                    viewPager.currentItem = 0
+                } else {
+                    viewPager.currentItem = viewPager.currentItem + 1
+                }
+            }
+        }
     }
 }

--- a/sample/src/main/res/layout/fragment_view_pager_sample.xml
+++ b/sample/src/main/res/layout/fragment_view_pager_sample.xml
@@ -8,7 +8,7 @@
         android:id="@+id/viewpager_pager_indicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_centerHorizontal="true"
         android:layout_margin="24dp"
         indefinite_pager_indicator:dotColor="@color/colorPrimaryDark"
         indefinite_pager_indicator:selectedDotColor="@color/colorPrimary" />
@@ -20,26 +20,30 @@
         android:layout_above="@+id/navigation_buttons_layout"
         android:layout_below="@+id/viewpager_pager_indicator" />
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/navigation_buttons_layout"
-        android:layout_width="wrap_content"
+        style="?attr/buttonBarStyle"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/viewpager"
+        android:layout_alignParentBottom="true"
+        android:background="@color/white"
+        android:elevation="2dp"
         android:orientation="horizontal">
 
         <Button
             android:id="@+id/viewpager_previous_button"
+            style="?attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="left"
             android:text="@string/previous" />
 
         <Button
             android:id="@+id/viewpager_next_button"
+            style="?attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="right"
+            android:layout_alignParentRight="true"
             android:text="@string/next" />
-    </LinearLayout>
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/sample/src/main/res/layout/fragment_view_pager_sample.xml
+++ b/sample/src/main/res/layout/fragment_view_pager_sample.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:indefinite_pager_indicator="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="wrap_content">
 
     <com.rbrooks.indefinitepagerindicator.IndefinitePagerIndicator
         android:id="@+id/viewpager_pager_indicator"
@@ -17,6 +16,30 @@
     <android.support.v4.view.ViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/navigation_buttons_layout"
+        android:layout_below="@+id/viewpager_pager_indicator" />
 
-</LinearLayout>
+    <LinearLayout
+        android:id="@+id/navigation_buttons_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/viewpager"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/viewpager_previous_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:text="@string/previous" />
+
+        <Button
+            android:id="@+id/viewpager_next_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:text="@string/next" />
+    </LinearLayout>
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/fragment_view_pager_sample.xml
+++ b/sample/src/main/res/layout/fragment_view_pager_sample.xml
@@ -27,19 +27,19 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/white"
-        android:elevation="2dp"
+        android:elevation="4dp"
         android:orientation="horizontal">
 
         <Button
             android:id="@+id/viewpager_previous_button"
-            style="?attr/buttonBarButtonStyle"
+            style="@style/PrimaryFlatButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/previous" />
 
         <Button
             android:id="@+id/viewpager_next_button"
-            style="?attr/buttonBarButtonStyle"
+            style="@style/PrimaryFlatButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -52,4 +52,7 @@
 
     <string name="see_original">See Original</string>
     <string name="choose_browser">Choose Browser</string>
+
+    <string name="previous">Previous</string>
+    <string name="next">Next</string>
 </resources>


### PR DESCRIPTION
- Fixes a bug that was caused when setting a ViewPager's position programmatically. 
- Updates the readme to reflect the v 1.0.2 repository change
- Updates my email in the gradle extensions
- Adds a next and previous button to the ViewPager sample

**Bug description & fix**
Calling `setCurrentItem(int position)` would not successfully update the indicator's position as the `intermediateSelectedItemPosition` was not updated in `onPageSelected(int position)`. To fix this, in `onPageSelected(int position)` the `intermediateSelectedItemPosition` was assigned the value of `selectedItemPosition` before `selectedItemPosition` was updated. 