### PR TITLE
Empty RecyclerView crash fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A lightweight, plug-and-play indefinite pager indicator for RecyclerViews &amp; 
 
 # Usage
 
- [ ![Download](https://api.bintray.com/packages/rbro112/maven/IndefinitePagerIndicator/images/download.svg?version=1.0.3) ](https://bintray.com/rbro112/maven/IndefinitePagerIndicator/1.0.3/link)
+ [ ![Download](https://api.bintray.com/packages/rbro112/maven/IndefinitePagerIndicator/images/download.svg?version=1.0.4) ](https://bintray.com/rbro112/maven/IndefinitePagerIndicator/1.0.4/link)
 
 To use the IndefinitePagerIndicator, simply add the gradle dependency to your module's `build.gradle` file:
 
 ```groovy
-compile 'com.ryanjeffreybrooks:indefinitepagerindicator:1.0.3'
+compile 'com.ryanjeffreybrooks:indefinitepagerindicator:1.0.4'
 ```
 
 Min SDK supported is version 16 - Jelly Bean.

--- a/indefinitepagerindicator/build.gradle
+++ b/indefinitepagerindicator/build.gradle
@@ -15,7 +15,7 @@ ext {
     siteUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator'
     gitUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator.git'
 
-    libraryVersion = '1.0.3'
+    libraryVersion = '1.0.4'
 
     developerId = 'rbro112'
     developerName = 'Ryan Brooks'

--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -230,7 +230,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
         offsetPercent = positionOffset * -1
         invalidate()
     }
-    
+
     override fun onPageSelected(position: Int) {
         intermediateSelectedItemPosition = selectedItemPosition
         selectedItemPosition = position
@@ -264,8 +264,11 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
         override fun onScrolled(recyclerView: RecyclerView?, dx: Int, dy: Int) {
 
             val view = getMostVisibleChild()
-            setIntermediateSelectedItemPosition(view)
-            offsetPercent = view!!.left.toFloat() / view.measuredWidth
+
+            if (view != null) {
+                setIntermediateSelectedItemPosition(view)
+                offsetPercent = view.left.toFloat() / view.measuredWidth
+            }
 
             val layoutManager = recyclerView?.layoutManager as LinearLayoutManager
             val visibleItemPosition = if (dx >= 0) layoutManager.findLastVisibleItemPosition() else layoutManager.findFirstVisibleItemPosition()

--- a/sample/src/main/java/com/rbrooks/indefinitepagerindicatorsample/util/PagerNumberPickerDialogPreference.kt
+++ b/sample/src/main/java/com/rbrooks/indefinitepagerindicatorsample/util/PagerNumberPickerDialogPreference.kt
@@ -16,7 +16,7 @@ class PagerNumberPickerDialogPreference : DialogFragment() {
     companion object {
         val KEY_NUM_PAGES = "num_pages"
 
-        val MIN_PAGES = 1
+        val MIN_PAGES = 0
         val MAX_PAGES = PhotoItem.values().size
         val DEFAULT_PAGES = 3
     }


### PR DESCRIPTION
- Fixes issue #6 found by @fengmlo where the IndefinitePagerIndicator would crash if RecyclerView was empty.
- Adds null check around calls that could have a null view passed in if RecyclerView empty.
- Adds test quantity of 0 to the sample app.
- Updates library to v 1.0.4.