### PR TITLE
Add RTL Support on Recycler Views

### DIFF
--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -230,9 +230,9 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
     private fun isRtl() = ViewCompat.getLayoutDirection(this) == ViewCompat.LAYOUT_DIRECTION_RTL
 
     /**
-     * Gets the RTL position of the Item
+     * Gets the RTL position of the position in any adapter
      */
-    private fun getRTLPosition(position: Int) = viewPager?.adapter?.count!! - position - 1
+    private fun getRTLPosition(position: Int) = getPagerItemCount() - position - 1
 
     /**
      * ViewPager.OnPageChangeListener implementation.
@@ -294,12 +294,14 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
                 offsetPercent = view.left.toFloat() / view.measuredWidth
             }
 
-            val layoutManager = recyclerView?.layoutManager as LinearLayoutManager
-            val visibleItemPosition = if (dx >= 0) layoutManager.findLastVisibleItemPosition() else layoutManager.findFirstVisibleItemPosition()
+            with(recyclerView?.layoutManager as LinearLayoutManager) {
+                val visibleItemPosition = if (dx >= 0) findLastVisibleItemPosition() else findFirstVisibleItemPosition()
 
-            if (previousMostVisibleChild !== layoutManager.findViewByPosition(visibleItemPosition)) {
-                selectedItemPosition = intermediateSelectedItemPosition
+                if (previousMostVisibleChild !== findViewByPosition(visibleItemPosition)) {
+                    selectedItemPosition = intermediateSelectedItemPosition
+                }
             }
+
             previousMostVisibleChild = view
             invalidate()
         }
@@ -340,7 +342,14 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
         }
 
         private fun setIntermediateSelectedItemPosition(mostVisibleChild: View?) {
-            intermediateSelectedItemPosition = recyclerView?.findContainingViewHolder(mostVisibleChild)?.adapterPosition!!
+            with(recyclerView?.findContainingViewHolder(mostVisibleChild)?.adapterPosition!!) {
+
+                intermediateSelectedItemPosition = if (isRtl()) {
+                    getRTLPosition(this)
+                } else {
+                    this
+                }
+            }
         }
     }
 }

--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -343,7 +343,6 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
 
         private fun setIntermediateSelectedItemPosition(mostVisibleChild: View?) {
             with(recyclerView?.findContainingViewHolder(mostVisibleChild)?.adapterPosition!!) {
-
                 intermediateSelectedItemPosition = if (isRtl()) {
                     getRTLPosition(this)
                 } else {


### PR DESCRIPTION
## What I did

Added support for RTL in the Recycler Views 🎉 🌮 

Since RTL on Recycler Views is supported out of the box (by this I mean that it handles the starting scrolling of the view in the end), we don't check if the flag is on or off because it creates a confusion on positions in the adapter.

This is how it is currently looking:

![](https://user-images.githubusercontent.com/6641413/35891557-40e3767a-0ba5-11e8-8052-19e60a75b27f.gif)
