### PR TITLE
Add AntiAlias to Paint for smoother circles

### DIFF
--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -84,6 +84,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(context: Context, attrs
         selectedDotPaint.color = selectedDotColor
         dotPaint.style = Paint.Style.FILL
         dotPaint.color = dotColor
+        dotPaint.isAntiAlias = true
     }
 
     /**


### PR DESCRIPTION
### Issue #12 

After reading a little bit on AntiAlias (since I didn't know the term) on the following blogpost:

https://medium.com/@ali.muzaffar/android-why-your-canvas-shapes-arent-smooth-aa2a3f450eb5

and you were drawing on Canvas without saving bitmaps to persist them, the solution to it would be just enabling the flag on AntiAlias. 

It does improve the smoothness on the dots 🎉 🌮 