### PR TITLE
Add readme & maven updates for v1.0.9 - Update Gradle & Kotlin versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A lightweight, plug-and-play indefinite pager indicator for RecyclerViews &amp; 
 
 # Usage
 
- [ ![Download](https://api.bintray.com/packages/rbro112/maven/IndefinitePagerIndicator/images/download.svg?version=1.0.8) ](https://bintray.com/rbro112/maven/IndefinitePagerIndicator/1.0.8/link)
+ [ ![Download](https://api.bintray.com/packages/rbro112/maven/IndefinitePagerIndicator/images/download.svg?version=1.0.9) ](https://bintray.com/rbro112/maven/IndefinitePagerIndicator/1.0.9/link)
 
 To use the IndefinitePagerIndicator, simply add the gradle dependency to your module's `build.gradle` file:
 
 ```groovy
-compile 'com.ryanjeffreybrooks:indefinitepagerindicator:1.0.8'
+compile 'com.ryanjeffreybrooks:indefinitepagerindicator:1.0.9'
 ```
 
 Min SDK supported is version 16 - Jelly Bean.

--- a/indefinitepagerindicator/build.gradle
+++ b/indefinitepagerindicator/build.gradle
@@ -15,7 +15,7 @@ ext {
     siteUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator'
     gitUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator.git'
 
-    libraryVersion = '1.0.8'
+    libraryVersion = '1.0.9'
 
     developerId = 'rbro112'
     developerName = 'Ryan Brooks'


### PR DESCRIPTION
- Updates library to v1.0.9 on Maven central: [IndefinitePagerIndicator on Bintray](https://bintray.com/rbro112/maven/IndefinitePagerIndicator)
- Updates readme to reflect v1.0.9 update.

Thanks @paul-turner! I appreciate the update!