### PR TITLE
Move to Jitpack to publish the newer versions of the Library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -24,5 +25,6 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,6 @@ buildscript {
     }
 }
 
-plugins {
-    id "com.github.dcendents.android-maven" version "2.0"
-    id "com.jfrog.bintray" version "1.8.0"
-}
-
 allprojects {
     repositories {
         google()

--- a/indefinitepagerindicator/build.gradle
+++ b/indefinitepagerindicator/build.gradle
@@ -1,30 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'com.github.dcendents.android-maven'
 
-ext {
-    bintrayRepo = 'maven'
-    bintrayName = 'IndefinitePagerIndicator'
-
-    publishedGroupId = 'com.ryanjeffreybrooks'
-    libraryName = 'IndefinitePagerIndicator'
-    artifact = 'indefinitepagerindicator'
-
-    libraryDescription = 'A lightweight, plug-and-play indefinite pager indicator for RecyclerViews & ViewPagers.'
-
-    siteUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator'
-    gitUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator.git'
-
-    libraryVersion = '1.0.10'
-
-    developerId = 'rbro112'
-    developerName = 'Ryan Brooks'
-    developerEmail = 'ryanjeffrey.brooks112@gmail.com'
-
-    licenseName = 'MIT License'
-    licenseUrl = 'https://github.com/rbro112/Android-Indefinite-Pager-Indicator/blob/master/LICENSE.md'
-    allLicenses = ["MIT"]
-}
+group = 'com.ryanjeffreybrooks.androidpagerindicator'
 
 android {
     compileSdkVersion 26
@@ -58,6 +37,3 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }
-
-apply from: '../gradle/bintray_installer.gradle'
-apply from: '../gradle/maven_installer.gradle'

--- a/indefinitepagerindicator/build.gradle
+++ b/indefinitepagerindicator/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group = 'com.ryanjeffreybrooks.androidpagerindicator'
+group = 'com.ryanjeffreybrooks.IndefinitePagerIndicator'
 
 android {
     compileSdkVersion 26
@@ -17,14 +17,6 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
     }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
-    }
-
 }
 
 dependencies {


### PR DESCRIPTION
We need to find an easier way to publish the newer versions of the library and since Jitpack relies completely on the releases here on Github, we decided to move to it :) 

https://jitpack.io/docs/ANDROID/

![](https://media.giphy.com/media/zczuaAkE8TDri/giphy.gif)