### PR TITLE
When using an indicator, there are cases in which the contents are se…

### DIFF
--- a/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
+++ b/indefinitepagerindicator/src/main/java/com/rbrooks/indefinitepagerindicator/IndefinitePagerIndicator.kt
@@ -25,6 +25,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(
     // region Members
 
     private companion object {
+        private const val DEFAULT_MAX_DOT_COUNT = 0
         private const val DEFAULT_DOT_COUNT = 5
         private const val DEFAULT_FADING_DOT_COUNT = 1
         private const val DEFAULT_DOT_RADIUS_DP = 4
@@ -39,6 +40,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(
     private var internalPageChangeCallback: InternalPageChangeCallback? = null
     private val interpolator = DecelerateInterpolator()
 
+    private var maxDotCount = DEFAULT_MAX_DOT_COUNT
     private var dotCount = DEFAULT_DOT_COUNT
     private var fadingDotCount = DEFAULT_FADING_DOT_COUNT
     private var selectedDotRadiusPx = dpToPx(
@@ -94,6 +96,10 @@ class IndefinitePagerIndicator @JvmOverloads constructor(
                 R.styleable.IndefinitePagerIndicator,
                 0,
                 0
+            )
+            maxDotCount = typedArray.getInteger(
+                R.styleable.IndefinitePagerIndicator_maxDotCount,
+                DEFAULT_MAX_DOT_COUNT
             )
             dotCount = typedArray.getInteger(
                 R.styleable.IndefinitePagerIndicator_dotCount,
@@ -220,6 +226,11 @@ class IndefinitePagerIndicator @JvmOverloads constructor(
 
     fun setDotCount(count: Int) {
         dotCount = count
+        invalidate()
+    }
+
+    fun setMaxDotCount(count: Int) {
+        maxDotCount = count
         invalidate()
     }
 
@@ -387,6 +398,7 @@ class IndefinitePagerIndicator @JvmOverloads constructor(
     }
 
     private fun getItemCount(): Int = when {
+        maxDotCount > 0 -> maxDotCount
         recyclerView != null -> recyclerView?.adapter?.itemCount ?: 0
         viewPager != null -> viewPager?.adapter?.count ?: 0
         viewPager2 != null -> viewPager2?.adapter?.itemCount ?: 0

--- a/indefinitepagerindicator/src/main/res/values/attrs.xml
+++ b/indefinitepagerindicator/src/main/res/values/attrs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="IndefinitePagerIndicator">
+        <attr name="maxDotCount" format="integer" />
         <attr name="dotCount" format="integer" />
         <attr name="fadingDotCount" format="integer" />
         <attr name="dotRadius" format="dimension" />


### PR DESCRIPTION
…arched in units of 20 when searching the API.

At this time, it is necessary to express the number of all contents on the indicator.
So, it was additionally processed with a variable called maxDotCount.

1. add maxDotCount variable
2. add setMaxDotCount method
3. modify getItemCount method